### PR TITLE
Add Qbox compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 * ... and all features from ps-hud/qb-hud
 
 ## Dependencies
-* Only QBCore is required
+* QBCore or Qbox (qbx-core) is required
 
 ## Optional:
 * [ps-buffs](https://github.com/Project-Sloth/ps-buffs)

--- a/client.lua
+++ b/client.lua
@@ -1,6 +1,7 @@
 -- CC SCRIPTS / HUD
 
-local QBCore = exports['qb-core']:GetCoreObject()
+local coreName = GetResourceState('qbx-core') ~= 'missing' and 'qbx-core' or 'qb-core'
+local QBCore = exports[coreName]:GetCoreObject()
 local serverId = GetPlayerServerId(PlayerId())
 local PlayerData = QBCore.Functions.GetPlayerData()
 local config = Config
@@ -80,7 +81,8 @@ local function hasHarness()
     if not IsPedInAnyVehicle(ped, false) then return end
 
     local _harness = false
-    local hasHarness = exports['qb-smallresources']:HasHarness()
+    local smallRes = GetResourceState('qbx-smallresources') ~= 'missing' and 'qbx-smallresources' or 'qb-smallresources'
+    local hasHarness = exports[smallRes]:HasHarness()
     if hasHarness then
         _harness = true
     else

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -6,11 +6,12 @@ description 'CC HUD Script'
 version '1.0.1'
 
 shared_scripts {
-	'@qb-core/shared/locale.lua',
-	'locales/en.lua',
-	'locales/*.lua',
-	'config.lua',
-	'uiconfig.lua'
+    '@qb-core/shared/locale.lua',
+    '@qbx-core/shared/locale.lua',
+    'locales/en.lua',
+    'locales/*.lua',
+    'config.lua',
+    'uiconfig.lua'
 }
 
 client_script 'client.lua'

--- a/server.lua
+++ b/server.lua
@@ -1,6 +1,7 @@
 -- CC SCRIPTS / HUD
 
-local QBCore = exports['qb-core']:GetCoreObject()
+local coreName = GetResourceState('qbx-core') ~= 'missing' and 'qbx-core' or 'qb-core'
+local QBCore = exports[coreName]:GetCoreObject()
 local ResetStress = false
 
 QBCore.Commands.Add('cash', Lang:t('info.check_cash_balance'), {}, false, function(source, args)


### PR DESCRIPTION
## Summary
- document Qbox framework requirement
- support `qbx-core` and `qbx-smallresources` when present

## Testing
- `npm install` *(fails: unable to resolve dependency tree)*
- `npm run check` *(fails: `svelte-check` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6853f1562340832a8969f848455cc683